### PR TITLE
Fix error using lesskey

### DIFF
--- a/less
+++ b/less
@@ -1,3 +1,4 @@
+#command
 n    forw-line
 e    back-line
 k    repeat-search


### PR DESCRIPTION
Using the file as-is caused an error when running lesskey. Adding the "#command" comment to the file fixes this problem.