### PR TITLE
Update VSCode vim key bindings for post-0.13.0

### DIFF
--- a/vscode.json
+++ b/vscode.json
@@ -11,7 +11,7 @@
             "after": ["<c-n>"]
         }
     ],
-    "vim.otherModesKeyBindings": [
+    "vim.normalModeKeyBindings": [
         {
             "before": ["<c-n>"],
             "after": ["<cr>"]
@@ -29,7 +29,75 @@
             "after": ["<right>"]
         }
     ],
-    "vim.otherModesKeyBindingsNonRecursive": [
+    "vim.visualModeKeyBindings": [
+        {
+            "before": ["<c-n>"],
+            "after": ["<cr>"]
+        },
+        {
+            "before": ["n"],
+            "after": ["<down>"]
+        },
+        {
+            "before": ["e"],
+            "after": ["<up>"]
+        },
+        {
+            "before": ["i"],
+            "after": ["<right>"]
+        }
+    ],
+    "vim.normalModeKeyBindingsNonRecursive": [
+        {
+            "before": ["<c-j>"],
+            "after": ["<c-n>"]
+        },
+        {
+            "before": ["k"],
+            "after": ["n"]
+        },
+        {
+            "before": ["K"],
+            "after": ["N"]
+        },
+        {
+            "before": ["u"],
+            "after": ["i"]
+        },
+        {
+            "before": ["U"],
+            "after": ["I"]
+        },
+        {
+            "before": ["l"],
+            "after": ["u"]
+        },
+        {
+            "before": ["L"],
+            "after": ["U"]
+        },
+        {
+            "before": ["N"],
+            "after": ["J"]
+        },
+        {
+            "before": ["E"],
+            "after": ["K"]
+        },
+        {
+            "before": ["I"],
+            "after": ["L"]
+        },
+        {
+            "before": ["j"],
+            "after": ["e"]
+        },
+        {
+            "before": ["J"],
+            "after": ["E"]
+        }
+    ],
+    "vim.visualModeKeyBindingsNonRecursive": [
         {
             "before": ["<c-j>"],
             "after": ["<c-n>"]
@@ -79,4 +147,5 @@
             "after": ["E"]
         }
     ]
+
 }


### PR DESCRIPTION
The VScode Vim plugin in 0.13.0 split the two "otherKeys" key binding settings in half to have direct normal mode and visual mode key bindings instead of merged key bindings. See: VSCode/Vim#2726